### PR TITLE
Update to support PHP 8

### DIFF
--- a/src/CpfValidator.php
+++ b/src/CpfValidator.php
@@ -35,18 +35,18 @@ class CpfValidator extends DocumentValidator
         $valid = true;
         $cpf = preg_replace('/[^0-9]/', '', $value);
 
-        for($x = 0; $x < 10; $x ++) {
-            if ($cpf == str_repeat ( $x, 11 )) {
+        for ($x = 0; $x < 10; $x++) {
+            if ($cpf == str_repeat($x, 11)) {
                 $valid = false;
             }
         }
         if ($valid) {
-            if (strlen ( $cpf ) != 11) {
+            if (strlen($cpf) != 11) {
                 $valid = false;
             } else {
-                for ($t = 9; $t < 11; $t ++) {
+                for ($t = 9; $t < 11; $t++) {
                     $d = 0;
-                    for($c = 0; $c < $t; $c ++) {
+                    for ($c = 0; $c < $t; $c++) {
                         $d += $cpf[$c] * (($t + 1) - $c);
                     }
                     $d = ((10 * $d) % 11) % 10;


### PR DESCRIPTION
Replaced {} by [] used for string offset access. Curly braces are not supported for this type of access in PHP 8. Did some code formatting.