### PR TITLE
Update to support PHP 8

### DIFF
--- a/src/CnpjValidator.php
+++ b/src/CnpjValidator.php
@@ -35,22 +35,22 @@ class CnpjValidator extends DocumentValidator
         $valid = true;
         $cnpj = preg_replace('/[^0-9_]/', '', $value);
 
-        for ($x=0; $x<10; $x++) {
-            if ( $cnpj == str_repeat($x, 14) ) {
+        for ($x = 0; $x < 10; $x++) {
+            if ($cnpj == str_repeat($x, 14)) {
                 $valid = false;
             }
         }
         if ($valid) {
             if (strlen($cnpj) != 14) {
                 $valid = false;
-            } else  {
-                for ($t = 12; $t < 14; $t ++) {
+            } else {
+                for ($t = 12; $t < 14; $t++) {
                     $d = 0;
                     $c = 0;
-                    for ($m = $t - 7; $m >= 2; $m --, $c ++) {
+                    for ($m = $t - 7; $m >= 2; $m--, $c++) {
                         $d += $cnpj[$c] * $m;
                     }
-                    for ($m = 9; $m >= 2; $m --, $c ++) {
+                    for ($m = 9; $m >= 2; $m--, $c++) {
                         $d += $cnpj[$c] * $m;
                     }
                     $d = ((10 * $d) % 11) % 10;


### PR DESCRIPTION
Replaced {} by [] used for string offset access. Curly braces are not supported for this type of access in PHP 8. Did some code formatting.